### PR TITLE
Use regex to parse string without making an array

### DIFF
--- a/dist/classnames-template-literals.cjs.js
+++ b/dist/classnames-template-literals.cjs.js
@@ -2,7 +2,7 @@
 
 function ctl(template) {
   return template
-    .replace(/(undefined|false|true)/g, '')
+    .replace(/\s(undefined|false|true)\s/g, '')
     .replace(/\s+/g, ' ')
     .trim()
 }

--- a/dist/classnames-template-literals.cjs.js
+++ b/dist/classnames-template-literals.cjs.js
@@ -1,14 +1,10 @@
 'use strict';
 
 function ctl(template) {
-  var trimmedClassnames = template.replace(/\s+/gm, " ");
-  var formattedClassnames = trimmedClassnames
-    .split(" ")
-    .filter((c) => c !== "false" && c !== "true" && c !== "undefined")
-    .join(" ")
-    .trim();
-
-  return formattedClassnames;
+  return template
+    .replace(/(undefined|false|true)/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
 }
 
 module.exports = ctl;

--- a/dist/classnames-template-literals.esm.js
+++ b/dist/classnames-template-literals.esm.js
@@ -1,12 +1,8 @@
 function ctl(template) {
-  var trimmedClassnames = template.replace(/\s+/gm, " ");
-  var formattedClassnames = trimmedClassnames
-    .split(" ")
-    .filter((c) => c !== "false" && c !== "true" && c !== "undefined")
-    .join(" ")
-    .trim();
-
-  return formattedClassnames;
+  return template
+    .replace(/(undefined|false|true)/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
 }
 
 export default ctl;

--- a/dist/classnames-template-literals.esm.js
+++ b/dist/classnames-template-literals.esm.js
@@ -1,6 +1,6 @@
 function ctl(template) {
   return template
-    .replace(/(undefined|false|true)/g, '')
+    .replace(/\s(undefined|false|true)\s/g, '')
     .replace(/\s+/g, ' ')
     .trim()
 }

--- a/dist/classnames-template-literals.umd.js
+++ b/dist/classnames-template-literals.umd.js
@@ -5,14 +5,10 @@
 }(this, (function () { 'use strict';
 
   function ctl(template) {
-    var trimmedClassnames = template.replace(/\s+/gm, " ");
-    var formattedClassnames = trimmedClassnames
-      .split(" ")
-      .filter((c) => c !== "false" && c !== "true" && c !== "undefined")
-      .join(" ")
-      .trim();
-
-    return formattedClassnames;
+    return template
+      .replace(/(undefined|false|true)/g, '')
+      .replace(/\s+/g, ' ')
+      .trim()
   }
 
   return ctl;

--- a/dist/classnames-template-literals.umd.js
+++ b/dist/classnames-template-literals.umd.js
@@ -6,7 +6,7 @@
 
   function ctl(template) {
     return template
-      .replace(/(undefined|false|true)/g, '')
+      .replace(/\s(undefined|false|true)\s/g, '')
       .replace(/\s+/g, ' ')
       .trim()
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "1.0.3",
   "author": "Netlify",
   "contributors": [
-    "Charlie Gerard <charlie@netlify.com> (https://charliegerard.dev)"
+    "Charlie Gerard <charlie@netlify.com> (https://charliegerard.dev)",
+    "EJ Mason <ej.mason@netlify.com> (https://www.ejmason.com)"
   ],
   "bugs": {
     "url": "https://github.com/netlify/classnames-template-literals/issues"

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,6 @@
 export default function ctl(template) {
-  var trimmedClassnames = template.replace(/\s+/gm, " ");
-  var formattedClassnames = trimmedClassnames
-    .split(" ")
-    .filter((c) => c !== "false" && c !== "true" && c !== "undefined")
-    .join(" ")
-    .trim();
-
-  return formattedClassnames;
+  return template
+    .replace(/(undefined|false|true)/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 export default function ctl(template) {
   return template
-    .replace(/(undefined|false|true)/g, '')
+    .replace(/\s(undefined|false|true)\s/g, '')
     .replace(/\s+/g, ' ')
     .trim()
 }

--- a/test/test.js
+++ b/test/test.js
@@ -22,3 +22,13 @@ test("should handle template literals", () => {
   expect(ctl(classname)).toBe("bg-black text-small mt-2 mb-3");
   expect(ctl(classname)).not.toBe("bg-black text-small mt-2 mb-3 ml-3");
 });
+
+test('should not remove `undefined`, `false`, or `true` if it is part of a classname', ()=> {
+	const className = `
+		bg-black
+		color-true-blue
+		arbitrary-false
+		arbitrary-undefined
+	`
+	expect(ctl(className)).toBe("bg-black color-true-blue arbitrary-false arbitrary-undefined")
+})


### PR DESCRIPTION
Thanks for making this utility, @charliegerard! I got curious about how it worked, so here I am! 

By using regex and `String#replace()` to modify the template string, we can make this thing a little more performant. I made [a JSBench test](https://jsbench.me/28kuos12dp/1), and it looks to be ~25% more performant on average.

I'd be happy to follow up with a separate PR to update our dev dependencies as well; just let me know!